### PR TITLE
Support negative balance values in EVS client

### DIFF
--- a/app/clients/evs.py
+++ b/app/clients/evs.py
@@ -36,7 +36,7 @@ class EvsClient:
 
     @staticmethod
     def _get_balance_from_text(text: str) -> float:
-        pattern = r'S\$ ((\d{1,3},)*\d{1,3}\.\d{2})'
+        pattern = r'S\$ (-?((\d{1,3},)*\d{1,3})\.\d{2})'
         matches = re.findall(pattern, text)
         assert len(matches) > 1, 'Could not find balance on page'
         match = matches[0][0].replace(',', '')

--- a/tests/clients/test_evs.py
+++ b/tests/clients/test_evs.py
@@ -46,6 +46,10 @@ class TestGetBalanceFromText(TestCase):
         with self.assertRaises(AssertionError):
             EvsClient._get_balance_from_text('S$ 10' * 2)
 
+    def test_negative(self):
+        text = 'S$ -1.00' * 2
+        self.assertEqual(EvsClient._get_balance_from_text(text), -1.0)
+
 
 class TestEvsClientLogin(BaseTest):
     def test_login_is_valid(self):


### PR DESCRIPTION
## Summary
Updated the EVS client's balance parsing logic to handle negative balance values, which can occur in certain account states.

## Changes
- Modified the regex pattern in `EvsClient._get_balance_from_text()` to capture optional negative signs (`-?`) before the numeric balance value
- Added test case `test_negative()` to verify that negative balances are correctly parsed and returned as negative floats

## Implementation Details
- The regex pattern was updated from `r'S\$ ((\d{1,3},)*\d{1,3}\.\d{2})'` to `r'S\$ (-?((\d{1,3},)*\d{1,3})\.\d{2})'` to optionally match a leading minus sign
- The existing balance extraction logic (removing commas and converting to float) naturally handles the negative sign without additional changes
- Test validates that a balance string like `'S$ -1.00'` correctly returns `-1.0`

https://claude.ai/code/session_01JPTiEMMamxvauxNcrWwjM1