### PR TITLE
Add GitHub Actions workflow for Fly.io deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,33 @@
+name: Deploy to Fly.io
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  deploy-api:
+    name: Deploy API
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: superfly/flyctl-actions/setup-flyctl@master
+
+      - name: Deploy evs-api
+        run: flyctl deploy --config fly.api.toml --remote-only
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN_API }}
+
+  deploy-bot:
+    name: Deploy Bot
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: superfly/flyctl-actions/setup-flyctl@master
+
+      - name: Deploy evs-bot
+        run: flyctl deploy --config fly.bot.toml --remote-only
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN_BOT }}


### PR DESCRIPTION
Deploy evs-api and evs-bot to Fly.io in parallel on every push to master. The
tokens are created via `fly tokens create deploy -a evs-(api|bot)`, so we have
separated deploy tokens for each app.